### PR TITLE
loosen illuminate dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "~4.0",
-        "illuminate/filesystem": "~4.0"
+        "illuminate/support": "~4.0|~5.0",
+        "illuminate/filesystem": "~4.0|~5.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9"


### PR DESCRIPTION
Hello Jason,

We're using this package over at Cartalyst, it works with Laravel 5's components without any additional changes.

Thanks!

Signed-off-by: Suhayb Wardany <me@suw.me>