### PR TITLE
Add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "jasonlewis/resource-watcher",
     "description": "Simple PHP resource watcher library.",
+    "license": "BSD-2-Clause",
     "keywords": ["resource", "assets", "laravel"],
     "authors": [
         {


### PR DESCRIPTION
By specifying the license in the `composer.json` file, Packagist and its API will be able to correctly know the license for this project