### PR TITLE
Changed "isModified" operator from "<" to "!=="

### DIFF
--- a/src/JasonLewis/ResourceWatcher/Resource/FileResource.php
+++ b/src/JasonLewis/ResourceWatcher/Resource/FileResource.php
@@ -93,7 +93,7 @@ class FileResource implements ResourceInterface
      */
     public function isModified()
     {
-        return $this->lastModified < $this->files->lastModified($this->path);
+        return $this->lastModified !== $this->files->lastModified($this->path);
     }
 
     /**


### PR DESCRIPTION
Two files share the same name, but different contents. One exists within the watched folder, the other, somewhere else. The other file has a modified time less than the watched file's modified time.

The other file is dragged/copied over the top of the watched file, but no `RESOURCE_MODIFIED` event fires.

The reason is because the `FileResource->isModified` method uses the `<` operator instead of the `!==` operator.

This PR fixes that.